### PR TITLE
Update "Dunder Mifflin Core Tokens" from zeroheight

### DIFF
--- a/tokens/style-dictionary.json/token_Scranton_Dark.json
+++ b/tokens/style-dictionary.json/token_Scranton_Dark.json
@@ -1,0 +1,32 @@
+{
+  "background": {
+    "hover": {
+      "primary": {
+        "type": "color",
+        "value": "#3399ff"
+      },
+      "secondary": {
+        "type": "color",
+        "value": "#1a1a1a"
+      }
+    },
+    "primary": {
+      "type": "color",
+      "value": "#4da6ff"
+    },
+    "secondary": {
+      "type": "color",
+      "value": "#202020"
+    }
+  },
+  "text": {
+    "primary": {
+      "type": "color",
+      "value": "#000000"
+    },
+    "secondary": {
+      "type": "color",
+      "value": "#ffffff"
+    }
+  }
+}

--- a/tokens/style-dictionary.json/token_Scranton_Light.json
+++ b/tokens/style-dictionary.json/token_Scranton_Light.json
@@ -1,0 +1,32 @@
+{
+  "background": {
+    "hover": {
+      "primary": {
+        "type": "color",
+        "value": "#003a91"
+      },
+      "secondary": {
+        "type": "color",
+        "value": "#e3eeff"
+      }
+    },
+    "primary": {
+      "type": "color",
+      "value": "#0047ab"
+    },
+    "secondary": {
+      "type": "color",
+      "value": "#ffffff"
+    }
+  },
+  "text": {
+    "primary": {
+      "type": "color",
+      "value": "#ff0000"
+    },
+    "secondary": {
+      "type": "color",
+      "value": "#0047ab"
+    }
+  }
+}


### PR DESCRIPTION

# Updated "**Dunder Mifflin Core Tokens**" from zeroheight

The token set "**Dunder Mifflin Core Tokens**" has been updated via a sync from zeroheight.

Tokens have been exported in the following formats: _**Style Dictionary**_

**Push initiated by:** Tom ([view token set on zeroheight](https://quabity-assuance.zeroheight.com/tokens/15058?token_set_source=figma_plugin))

_Review the changes to ensure the tokens have been updated accordingly_
