### PR TITLE
Update "multisource" from zeroheight

### DIFF
--- a/tokens/tokens_Mode1_Dark_BrandA_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandA_Dark.tokens.json
@@ -1,0 +1,590 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549019607843,
+          0.40784313725490196,
+          0.03137254901960784
+        ],
+        "alpha": 1.0,
+        "hex": "#ef6808"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27879
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921568627451,
+          0.6274509803921569,
+          0.3803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#faa061"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27884
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27855
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14901960784313725,
+          0.14901960784313725,
+          0.14901960784313725
+        ],
+        "alpha": 1.0,
+        "hex": "#262626"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27858
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8156862745098039,
+          0.8156862745098039,
+          0.8156862745098039
+        ],
+        "alpha": 1.0,
+        "hex": "#d0d0d0"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27861
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3254901960784314,
+          0.3215686274509804,
+          0.3215686274509804
+        ],
+        "alpha": 1.0,
+        "hex": "#535252"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27864
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27867
+      }
+    },
+    "size10": {
+      "$value": 4,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27870
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27873
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27876
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27888
+      }
+    },
+    "text-primary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27894
+      }
+    },
+    "text-secondary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27900
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Dark_BrandA_Light.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandA_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549019607843,
+          0.40784313725490196,
+          0.03137254901960784
+        ],
+        "alpha": 1.0,
+        "hex": "#ef6808"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27879
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921568627451,
+          0.6274509803921569,
+          0.3803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#faa061"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27884
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27855
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14901960784313725,
+          0.14901960784313725,
+          0.14901960784313725
+        ],
+        "alpha": 1.0,
+        "hex": "#262626"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27858
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8156862745098039,
+          0.8156862745098039,
+          0.8156862745098039
+        ],
+        "alpha": 1.0,
+        "hex": "#d0d0d0"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27861
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3254901960784314,
+          0.3215686274509804,
+          0.3215686274509804
+        ],
+        "alpha": 1.0,
+        "hex": "#535252"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27864
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27867
+      }
+    },
+    "size10": {
+      "$value": 4,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27870
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27873
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27876
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Dark_BrandB_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandB_Dark.tokens.json
@@ -1,0 +1,590 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.03137254901960784,
+          0.36470588235294116,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#085def"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27881
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3803921568627451,
+          0.6,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#6199fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27886
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27856
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27859
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27862
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27865
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27868
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27871
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27874
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27877
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27888
+      }
+    },
+    "text-primary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27894
+      }
+    },
+    "text-secondary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27900
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Dark_BrandB_Light.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandB_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.03137254901960784,
+          0.36470588235294116,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#085def"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27881
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3803921568627451,
+          0.6,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#6199fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27886
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27856
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27859
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27862
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27865
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27868
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27871
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27874
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27877
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Dark_BrandC_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandC_Dark.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6352941176470588,
+          0.03137254901960784,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#a208ef"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27851
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27854
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27857
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27860
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27863
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27866
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27869
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27872
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27875
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27878
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Dark_BrandC_Light.tokens.json
+++ b/tokens/tokens_Mode1_Dark_BrandC_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27832
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.17647058823529413,
+            0.17647058823529413,
+            0.17647058823529413
+          ],
+          "alpha": 1.0,
+          "hex": "#2d2d2d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27834
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.23529411764705882,
+            0.22745098039215686,
+            0.20784313725490197
+          ],
+          "alpha": 1.0,
+          "hex": "#3c3a35"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27836
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.32941176470588235,
+            0.3215686274509804,
+            0.2980392156862745
+          ],
+          "alpha": 1.0,
+          "hex": "#54524c"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27838
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.2235294117647059,
+            0.07450980392156863,
+            0.43137254901960786
+          ],
+          "alpha": 1.0,
+          "hex": "#39136e"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27840
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3764705882352941,
+            0.1843137254901961,
+            0.7176470588235294
+          ],
+          "alpha": 1.0,
+          "hex": "#602fb7"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27842
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.09803921568627451,
+            0.3843137254901961,
+            0.050980392156862744
+          ],
+          "alpha": 1.0,
+          "hex": "#19620d"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27844
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4470588235294118,
+            0.08235294117647059,
+            0.08235294117647059
+          ],
+          "alpha": 1.0,
+          "hex": "#721515"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27846
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27848
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6352941176470588,
+          0.03137254901960784,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#a208ef"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27851
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27854
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27857
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27860
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27863
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27866
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27869
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27872
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27875
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27878
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandA_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandA_Dark.tokens.json
@@ -1,0 +1,590 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549019607843,
+          0.40784313725490196,
+          0.03137254901960784
+        ],
+        "alpha": 1.0,
+        "hex": "#ef6808"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27879
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921568627451,
+          0.6274509803921569,
+          0.3803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#faa061"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27884
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27855
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14901960784313725,
+          0.14901960784313725,
+          0.14901960784313725
+        ],
+        "alpha": 1.0,
+        "hex": "#262626"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27858
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8156862745098039,
+          0.8156862745098039,
+          0.8156862745098039
+        ],
+        "alpha": 1.0,
+        "hex": "#d0d0d0"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27861
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3254901960784314,
+          0.3215686274509804,
+          0.3215686274509804
+        ],
+        "alpha": 1.0,
+        "hex": "#535252"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27864
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27867
+      }
+    },
+    "size10": {
+      "$value": 4,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27870
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27873
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27876
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27888
+      }
+    },
+    "text-primary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27894
+      }
+    },
+    "text-secondary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27900
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandA_Light.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandA_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9372549019607843,
+          0.40784313725490196,
+          0.03137254901960784
+        ],
+        "alpha": 1.0,
+        "hex": "#ef6808"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27879
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9803921568627451,
+          0.6274509803921569,
+          0.3803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#faa061"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27884
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27855
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14901960784313725,
+          0.14901960784313725,
+          0.14901960784313725
+        ],
+        "alpha": 1.0,
+        "hex": "#262626"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27858
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8156862745098039,
+          0.8156862745098039,
+          0.8156862745098039
+        ],
+        "alpha": 1.0,
+        "hex": "#d0d0d0"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27861
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3254901960784314,
+          0.3215686274509804,
+          0.3215686274509804
+        ],
+        "alpha": 1.0,
+        "hex": "#535252"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27864
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27867
+      }
+    },
+    "size10": {
+      "$value": 4,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27870
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27873
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27876
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandB_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandB_Dark.tokens.json
@@ -1,0 +1,590 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.03137254901960784,
+          0.36470588235294116,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#085def"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27881
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3803921568627451,
+          0.6,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#6199fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27886
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27856
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27859
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27862
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27865
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27868
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27871
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27874
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27877
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27888
+      }
+    },
+    "text-primary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27894
+      }
+    },
+    "text-secondary": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27900
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandB_Light.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandB_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.03137254901960784,
+          0.36470588235294116,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#085def"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27881
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3803921568627451,
+          0.6,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#6199fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27886
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27856
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27859
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27862
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27865
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27868
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27871
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27874
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27877
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandC_Dark.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandC_Dark.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6352941176470588,
+          0.03137254901960784,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#a208ef"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27851
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27854
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27857
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27860
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27863
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27866
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27869
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27872
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27875
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27878
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}

--- a/tokens/tokens_Mode1_Light_BrandC_Light.tokens.json
+++ b/tokens/tokens_Mode1_Light_BrandC_Light.tokens.json
@@ -1,0 +1,551 @@
+{
+  "Core": {
+    "Blue": {
+      "Blue00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27817
+        }
+      },
+      "Blue05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9019607843137255,
+            0.9372549019607843,
+            0.996078431372549
+          ],
+          "alpha": 1.0,
+          "hex": "#e6effe"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27818
+        }
+      },
+      "Blue10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.7647058823529411,
+            0.8509803921568627,
+            0.9921568627450981
+          ],
+          "alpha": 1.0,
+          "hex": "#c3d9fd"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27819
+        }
+      },
+      "Blue20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5725490196078431,
+            0.7254901960784313,
+            0.9882352941176471
+          ],
+          "alpha": 1.0,
+          "hex": "#92b9fc"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27820
+        }
+      },
+      "Blue30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3803921568627451,
+            0.6,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#6199fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27821
+        }
+      },
+      "Blue40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.18823529411764706,
+            0.4745098039215686,
+            0.9725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#3079f8"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27822
+        }
+      },
+      "Blue50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.03137254901960784,
+            0.36470588235294116,
+            0.9372549019607843
+          ],
+          "alpha": 1.0,
+          "hex": "#085def"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27823
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3571
+      }
+    },
+    "Orange": {
+      "Orange00": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27824
+        }
+      },
+      "Orange05": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            0.9764705882352941,
+            0.9607843137254902
+          ],
+          "alpha": 1.0,
+          "hex": "#fff9f5"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27825
+        }
+      },
+      "Orange10": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9921568627450981,
+            0.8588235294117647,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#fddbc3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27826
+        }
+      },
+      "Orange20": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9882352941176471,
+            0.7450980392156863,
+            0.5725490196078431
+          ],
+          "alpha": 1.0,
+          "hex": "#fcbe92"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27827
+        }
+      },
+      "Orange30": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9803921568627451,
+            0.6274509803921569,
+            0.3803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#faa061"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27828
+        }
+      },
+      "Orange40": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9725490196078431,
+            0.5137254901960784,
+            0.18823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#f88330"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27829
+        }
+      },
+      "Orange50": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.40784313725490196,
+            0.03137254901960784
+          ],
+          "alpha": 1.0,
+          "hex": "#ef6808"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27830
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3572
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 323
+    }
+  },
+  "Semantic": {
+    "Number": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27831
+      }
+    },
+    "surface": {
+      "primary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "alpha": 1.0,
+          "hex": "#ffffff"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27833
+        }
+      },
+      "secondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9450980392156862,
+            0.9294117647058824,
+            0.8941176470588236
+          ],
+          "alpha": 1.0,
+          "hex": "#f1ede4"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27835
+        }
+      },
+      "tertiary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.8588235294117647,
+            0.8352941176470589,
+            0.7647058823529411
+          ],
+          "alpha": 1.0,
+          "hex": "#dbd5c3"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27837
+        }
+      },
+      "brandPrimary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.4627450980392157,
+            0.09411764705882353,
+            0.9803921568627451
+          ],
+          "alpha": 1.0,
+          "hex": "#7618fa"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27839
+        }
+      },
+      "brandSecondary": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.6039215686274509,
+            0.4,
+            0.9490196078431372
+          ],
+          "alpha": 1.0,
+          "hex": "#9a66f2"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27841
+        }
+      },
+      "success": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.1450980392156863,
+            0.7764705882352941,
+            0.03529411764705882
+          ],
+          "alpha": 1.0,
+          "hex": "#25c609"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27843
+        }
+      },
+      "danger": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.9372549019607843,
+            0.12941176470588237,
+            0.12941176470588237
+          ],
+          "alpha": 1.0,
+          "hex": "#ef2121"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27845
+        }
+      },
+      "information": {
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.3568627450980392,
+            0.6549019607843137,
+            0.8823529411764706
+          ],
+          "alpha": 1.0,
+          "hex": "#5ba7e1"
+        },
+        "$type": "color",
+        "$extensions": {
+          "com.zeroheight.tokenId": 27847
+        }
+      },
+      "$extensions": {
+        "com.zeroheight.tokenGroupId": 3574
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 324
+    }
+  },
+  "Brands": {
+    "brand-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6352941176470588,
+          0.03137254901960784,
+          0.9372549019607843
+        ],
+        "alpha": 1.0,
+        "hex": "#a208ef"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27851
+      }
+    },
+    "brand-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7607843137254902,
+          0.3803921568627451,
+          0.9803921568627451
+        ],
+        "alpha": 1.0,
+        "hex": "#c261fa"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27854
+      }
+    },
+    "text-primary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27857
+      }
+    },
+    "text-primary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12156862745098039,
+          0.15294117647058825,
+          0.23921568627450981
+        ],
+        "alpha": 1.0,
+        "hex": "#1f273d"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27860
+      }
+    },
+    "text-secondary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7529411764705882,
+          0.8352941176470589,
+          0.8745098039215686
+        ],
+        "alpha": 1.0,
+        "hex": "#c0d5df"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27863
+      }
+    },
+    "text-secondary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24313725490196078,
+          0.3254901960784314,
+          0.3764705882352941
+        ],
+        "alpha": 1.0,
+        "hex": "#3e5360"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27866
+      }
+    },
+    "size00": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27869
+      }
+    },
+    "size10": {
+      "$value": 0,
+      "$type": "number",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27872
+      }
+    },
+    "text-tertiary-light": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "alpha": 1.0,
+        "hex": "#ffffff"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27875
+      }
+    },
+    "text-tertiary-dark": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47843137254901963,
+          0.4627450980392157,
+          0.4627450980392157
+        ],
+        "alpha": 1.0,
+        "hex": "#7a7676"
+      },
+      "$type": "color",
+      "$extensions": {
+        "com.zeroheight.tokenId": 27878
+      }
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 325
+    }
+  },
+  "Modes": {
+    "brand": {
+      "$value": "{Brands.brand-dark}"
+    },
+    "text-primary": {
+      "$value": "{Brands.text-primary-dark}"
+    },
+    "text-secondary": {
+      "$value": "{Brands.text-secondary-dark}"
+    },
+    "$extensions": {
+      "com.zeroheight.collectionId": 326
+    }
+  },
+  "$extensions": {
+    "com.zeroheight.tokenSetId": 58,
+    "com.zeroheight.tokenSetVersionId": 175
+  }
+}


### PR DESCRIPTION

# Updated "**multisource**" from zeroheight

- Introduced comprehensive Core color scales for Blue (Blue00–Blue50) and Orange (Orange00–Orange50) across all mode/brand files.
- Added Semantic surface tokens (primary, secondary, tertiary, brandPrimary/Secondary, success, danger, information) and a new Semantic.Number token.
- Established brand text and color tokens per brand (brand-light/dark, text-primary/secondary/tertiary for light/dark) plus size tokens (Brands.size00/size10).
- Defined Modes mappings for brand and text tokens; some modes reference brand/text tokens via aliases, while others set explicit hex values (notably in Dark variants for BrandA and BrandB). 
- No tokens were removed or modified; all changes are additive.

Tokens have been exported in the following formats: _**DTCG JSON**_

**Push initiated by:** Tom ([view token set on zeroheight](https://team.zeroheight.com/tokens/58?token_set_source=figma_plugin))

_Review the changes to ensure the tokens have been updated accordingly_
